### PR TITLE
Fix cases where syslog_drain_url isn't specified

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -32,6 +32,10 @@
 			"Rev": "6807e777504f54ad073ecef66747de158294b639"
 		},
 		{
+			"ImportPath": "github.com/martini-contrib/auth",
+			"Rev": "fa62c19b7ae87da370242054c8beb11af31d327f"
+		},
+		{
 			"ImportPath": "github.com/mitchellh/mapstructure",
 			"Rev": "281073eb9eb092240d33ef253c404f1cca550309"
 		}

--- a/Godeps/_workspace/src/github.com/martini-contrib/auth/LICENSE
+++ b/Godeps/_workspace/src/github.com/martini-contrib/auth/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2013 Jeremy Saenz
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/Godeps/_workspace/src/github.com/martini-contrib/auth/README.md
+++ b/Godeps/_workspace/src/github.com/martini-contrib/auth/README.md
@@ -1,0 +1,67 @@
+# auth [![wercker status](https://app.wercker.com/status/8e5237b01b52f169a1274fad9a89617b "wercker status")](https://app.wercker.com/project/bykey/8e5237b01b52f169a1274fad9a89617b)
+Martini middleware/handler for http basic authentication.
+
+[API Reference](http://godoc.org/github.com/martini-contrib/auth)
+
+## Simple Usage
+
+Use `auth.Basic` to authenticate against a pre-defined username and password:
+
+~~~ go
+import (
+  "github.com/go-martini/martini"
+  "github.com/martini-contrib/auth"
+)
+
+func main() {
+  m := martini.Classic()
+  // authenticate every request
+  m.Use(auth.Basic("username", "secretpassword"))
+  m.Run()
+}
+~~~
+
+## Advanced Usage
+
+Using `auth.BasicFunc` lets you authenticate on a per-user level, by checking
+the username and password in the callback function:
+
+~~~ go
+import (
+  "github.com/go-martini/martini"
+  "github.com/martini-contrib/auth"
+)
+
+func main() {
+  m := martini.Classic()
+  // authenticate every request
+  m.Use(auth.BasicFunc(func(username, password string) bool {
+    return username == "admin" && password == "guessme"
+  }))
+  m.Run()
+}
+~~~
+
+Note that checking usernames and passwords with string comparison might be
+susceptible to timing attacks. To avoid that, use `auth.SecureCompare` instead:
+
+~~~ go
+  m.Use(auth.BasicFunc(func(username, password string) bool {
+    return auth.SecureCompare(username, "admin") && auth.SecureCompare(password, "guessme")
+  }))
+}
+~~~
+
+Upon successful authentication, the username is available to all subsequent
+handlers via the `auth.User` type:
+
+~~~ go
+  m.Get("/", func(user auth.User) string {
+    return "Welcome, " + string(user)
+  })
+}
+~~~
+
+## Authors
+* [Jeremy Saenz](http://github.com/codegangsta)
+* [Brendon Murphy](http://github.com/bemurphy)

--- a/Godeps/_workspace/src/github.com/martini-contrib/auth/basic.go
+++ b/Godeps/_workspace/src/github.com/martini-contrib/auth/basic.go
@@ -1,0 +1,56 @@
+package auth
+
+import (
+	"encoding/base64"
+	"github.com/go-martini/martini"
+	"net/http"
+	"strings"
+)
+
+// User is the authenticated username that was extracted from the request.
+type User string
+
+// BasicRealm is used when setting the WWW-Authenticate response header.
+var BasicRealm = "Authorization Required"
+
+// Basic returns a Handler that authenticates via Basic Auth. Writes a http.StatusUnauthorized
+// if authentication fails.
+func Basic(username string, password string) martini.Handler {
+	var siteAuth = base64.StdEncoding.EncodeToString([]byte(username + ":" + password))
+	return func(res http.ResponseWriter, req *http.Request, c martini.Context) {
+		auth := req.Header.Get("Authorization")
+		if !SecureCompare(auth, "Basic "+siteAuth) {
+			unauthorized(res)
+			return
+		}
+		c.Map(User(username))
+	}
+}
+
+// BasicFunc returns a Handler that authenticates via Basic Auth using the provided function.
+// The function should return true for a valid username/password combination.
+func BasicFunc(authfn func(string, string) bool) martini.Handler {
+	return func(res http.ResponseWriter, req *http.Request, c martini.Context) {
+		auth := req.Header.Get("Authorization")
+		if len(auth) < 6 || auth[:6] != "Basic " {
+			unauthorized(res)
+			return
+		}
+		b, err := base64.StdEncoding.DecodeString(auth[6:])
+		if err != nil {
+			unauthorized(res)
+			return
+		}
+		tokens := strings.SplitN(string(b), ":", 2)
+		if len(tokens) != 2 || !authfn(tokens[0], tokens[1]) {
+			unauthorized(res)
+			return
+		}
+		c.Map(User(tokens[0]))
+	}
+}
+
+func unauthorized(res http.ResponseWriter) {
+	res.Header().Set("WWW-Authenticate", "Basic realm=\""+BasicRealm+"\"")
+	http.Error(res, "Not Authorized", http.StatusUnauthorized)
+}

--- a/Godeps/_workspace/src/github.com/martini-contrib/auth/util.go
+++ b/Godeps/_workspace/src/github.com/martini-contrib/auth/util.go
@@ -1,0 +1,14 @@
+package auth
+
+import (
+	"crypto/sha256"
+	"crypto/subtle"
+)
+
+// SecureCompare performs a constant time compare of two strings to limit timing attacks.
+func SecureCompare(given string, actual string) bool {
+	givenSha := sha256.Sum256([]byte(given))
+	actualSha := sha256.Sum256([]byte(actual))
+
+	return subtle.ConstantTimeCompare(givenSha[:], actualSha[:]) == 1
+}

--- a/Godeps/_workspace/src/github.com/martini-contrib/auth/wercker.yml
+++ b/Godeps/_workspace/src/github.com/martini-contrib/auth/wercker.yml
@@ -1,0 +1,1 @@
+box: wercker/golang@1.1.1

--- a/README.md
+++ b/README.md
@@ -74,6 +74,21 @@ cf restart $APPNAME
 
 Each application will need rebind and restart/restage to get the new credentials.
 
+### Basic Authentication
+
+Set the environment variables `AUTH_USER` and `AUTH_PASSWORD` to enable basic authentication for the broker.
+
+This is useful to prevent unauthorized access to the credentials exposed by the broker (e.g. by somebody doing a `curl -X PUT http://$SERVICE_URL/v2/service_instances/a/service_bindings/b`).
+
+To do so (of course, change `secret_user` and `secret_password` to something more secret):
+
+```
+cf set-env $APPNAME AUTH_USER secret_user
+cf set-env $APPNAME AUTH_PASSWORD secret_password
+cf restart $APPNAME
+cf update-service-broker $SERVICE secret_user secret_password https://$SERVICE_URL
+```
+
 ### syslog_drain_url
 
 The broker can advertise a `syslog_drain_url` endpoint with the `$SYSLOG_DRAIN_URL` variable:

--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ type serviceInstanceResponse struct {
 
 type serviceBindingResponse struct {
 	Credentials    map[string]interface{} `json:"credentials"`
-	SyslogDrainURL string                 `json:"syslog_drain_url"`
+	SyslogDrainURL string                 `json:"syslog_drain_url,omitempty"`
 }
 
 var serviceName, servicePlan, baseGUID, tags, imageURL string

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cloudfoundry-community/go-cfenv"
 	"github.com/cloudfoundry-community/types-cf"
 	"github.com/go-martini/martini"
+	"github.com/martini-contrib/auth"
 	"github.com/kr/pretty"
 )
 
@@ -26,7 +27,7 @@ type serviceBindingResponse struct {
 	SyslogDrainURL string                 `json:"syslog_drain_url,omitempty"`
 }
 
-var serviceName, servicePlan, baseGUID, tags, imageURL string
+var serviceName, servicePlan, baseGUID, authUser, authPassword, tags, imageURL string
 var serviceBinding serviceBindingResponse
 var appURL string
 
@@ -134,6 +135,13 @@ func main() {
 	servicePlan = os.Getenv("SERVICE_PLAN")
 	if servicePlan == "" {
 		servicePlan = "shared"
+	}
+
+	authUser = os.Getenv("AUTH_USER")
+	authPassword = os.Getenv("AUTH_PASSWORD")
+	if (authUser != "") && (authPassword != "") {
+		// secure service broker with basic auth if both env variables are set
+		m.Use(auth.Basic(authUser, authPassword))
 	}
 
 	serviceBinding.SyslogDrainURL = os.Getenv("SYSLOG_DRAIN_URL")


### PR DESCRIPTION
Suppresses syslog_drain_url when empty.
Fixes #4 which came in via c1ea8e7f543c56484e9ca26724cfbd345f44b898 and also turned out to be an issue for me.
