### PR TITLE
Fix cases where syslog_drain_url isn't specified

### DIFF
--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ type serviceInstanceResponse struct {
 
 type serviceBindingResponse struct {
 	Credentials    map[string]interface{} `json:"credentials"`
-	SyslogDrainURL string                 `json:"syslog_drain_url"`
+	SyslogDrainURL string                 `json:"syslog_drain_url,omitempty"`
 }
 
 var serviceName, servicePlan, baseGUID, tags, imageURL string


### PR DESCRIPTION
Suppresses syslog_drain_url when empty.
Fixes #4 which came in via c1ea8e7f543c56484e9ca26724cfbd345f44b898 and also turned out to be an issue for me.
