### PR TITLE
Fix for syslog_drain_url being present when empty

### DIFF
--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ type serviceInstanceResponse struct {
 
 type serviceBindingResponse struct {
 	Credentials    map[string]interface{} `json:"credentials"`
-	SyslogDrainURL string                 `json:"syslog_drain_url"`
+	SyslogDrainURL string                 `json:"syslog_drain_url,omitempty"`
 }
 
 var serviceName, servicePlan, baseGUID, tags, imageURL string


### PR DESCRIPTION
Without this fix binding to WSSB instance could fail with:

```
Binding service AAA to app BBB in org DDD / space EEE as FFF...
FAILED
Server error, status code: 502, error code: 10001, message: The service is attempting to stream logs from your application, but is not registered as a logging service. Please contact the service provider.
```
